### PR TITLE
allow tupelo containers to be built from mounted path

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,3 +43,19 @@ volumes:
 Then simply use docker for tests / app in a container as normal. Mounting `tupelo-local:/tupelo-local` will provide assitance in running against this localnet:
 - notary group config at `/tupelo-local/config/notarygroup.toml`
 - `/tupelo-local/wait-for-tupelo.sh` which will sleep until tupelo is running, then exec the provided command
+
+
+## Building Tupelo from source
+Sometimes it may be desirable to build tupelo from source rather than point to a published image, such as for testing the tupelo repo itself. In this case, you can specify `TUPELO_BUILD_PATH` environment variable to the `tupelo` service along with a mounted directory, at which point it will do a `docker-compose build` on that path for the tupelo bootstrap and signer nodes. For example the `tupelo` service would look like:
+
+``` yaml
+services:
+  tupelo:
+    image: quorumcontrol/tupelo-local:latest
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+      - tupelo-local:/tupelo-local
+      - .:/src/tupelo # EXAMPLE: Mount from and to any valid directory
+    environment:
+      TUPELO_BUILD_PATH: /src/tupelo # EXAMPLE: Matching the mount path above
+```

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -3,6 +3,7 @@ version: "3"
 services:
   bootstrap:
     image: quorumcontrol/tupelo:${TUPELO_VERSION}
+    build: "${TUPELO_BUILD_PATH}"
     command: ["bootstrap-node", "--config", "/tupelo-local/config/bootstrap.toml", 
       "-L", "${TUPELO_LOG_LEVEL:-error}"]
     volumes:
@@ -15,6 +16,7 @@ services:
       
   node0:
     image: quorumcontrol/tupelo:${TUPELO_VERSION}
+    build: "${TUPELO_BUILD_PATH}"
     volumes:
       - tupelo-local:/tupelo-local
     command: ["test-node", "--config", "/tupelo-local/config/node0.toml",
@@ -22,6 +24,7 @@ services:
 
   node1:
     image: quorumcontrol/tupelo:${TUPELO_VERSION}
+    build: "${TUPELO_BUILD_PATH}"
     volumes:
       - tupelo-local:/tupelo-local
     command: ["test-node", "--config", "/tupelo-local/config/node1.toml",
@@ -29,6 +32,7 @@ services:
   
   node2:
     image: quorumcontrol/tupelo:${TUPELO_VERSION}
+    build: "${TUPELO_BUILD_PATH}"
     volumes:
       - tupelo-local:/tupelo-local
     command: ["test-node", "--config", "/tupelo-local/config/node2.toml",

--- a/docker/run.sh
+++ b/docker/run.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 # using the same docker-compose project name allows these containers to be cleaned up
 # with the parent by using `docker-compose down --remove-orphans -v`
@@ -7,20 +7,27 @@ net=$(docker inspect $(hostname) | jq -r ".[0].NetworkSettings.Networks[\"${proj
 volume=$(docker inspect $(hostname) | jq -r ".[0].Mounts[] | select(.Type == \"volume\" and .Destination == \"/tupelo-local\") | .Name")
 
 export TUPELO_VERSION=${TUPELO_VERSION:-master}
+export TUPELO_BUILD_PATH=${TUPELO_BUILD_PATH:-}
 export COMMUNITY_VERSION=${COMMUNITY_VERSION:-$TUPELO_VERSION}
 export NETWORK_NAME=$net
 export VOLUME_NAME=$volume
+
+dockerCompose="docker-compose -f ./docker-compose.yml -p $project"
+
+if [[ "$TUPELO_BUILD_PATH" != "" ]]; then
+  $dockerCompose build
+fi
 
 # This runs in background, waits for the 3 tupelo nodes to print out "started signer host",
 # at which point it will touch a file on the shared volume so `wait-for-tupelo.sh` can trigger
 trackStart() {
   started=0
   while [ "$started" -lt "3" ]; do
-    started=$(docker-compose -f ./docker-compose.yml -p $project logs | grep "started signer host" | sort | uniq | wc -l)
+    started=$($dockerCompose logs | grep "started signer host" | sort | uniq | wc -l)
     sleep 0.5
   done
   touch /tupelo-local/started
 }
 trackStart &
 
-exec docker-compose -f ./docker-compose.yml -p $project up
+exec $dockerCompose up


### PR DESCRIPTION
This adds support for using this inside the tupelo repo by supporting building the tupelo images from a source directory, usage looks like

https://github.com/quorumcontrol/tupelo-local/blob/692a810b691b0b1bc609de3a8ed004a9f0757d03/README.md#building-tupelo-from-source