### PR TITLE
Fix non-build workflow on docker-compose 1.25.0

### DIFF
--- a/docker/config/bootstrap.toml
+++ b/docker/config/bootstrap.toml
@@ -1,6 +1,7 @@
 Port = 34001
 BootstrapOnly = true
 NotaryGroupConfig = "./notarygroup.toml"
+StoragePath = "/tupelo/data"
 
 [PrivateKeySet]
 SignKeyHex = "0x1ef1cf13d52b2dbf3134d7fff6aa617c5cdac42ed89bd20007bfc93d00f0d0c6"

--- a/docker/config/node0.toml
+++ b/docker/config/node0.toml
@@ -1,4 +1,5 @@
 NotaryGroupConfig = "./notarygroup.toml"
+StoragePath = "/tupelo/data"
 
 [PrivateKeySet]
 SignKeyHex = "0x4344e3372f1b790016ed86400611fab64d0bba91136518685a7ce34106f1c759"

--- a/docker/config/node1.toml
+++ b/docker/config/node1.toml
@@ -1,5 +1,5 @@
 NotaryGroupConfig = "./notarygroup.toml"
-
+StoragePath = "/tupelo/data"
 
 [PrivateKeySet]
 SignKeyHex = "0x39a9b8ab3266811852b8b18d1fd0562ffc907f3ecba297c9b2a89f742d349dc9"

--- a/docker/config/node2.toml
+++ b/docker/config/node2.toml
@@ -1,4 +1,5 @@
 NotaryGroupConfig = "./notarygroup.toml"
+StoragePath = "/tupelo/data"
 
 [PrivateKeySet]
 SignKeyHex = "0x558a546adacea3d761741bf4a6415ef2eeb85bfa457036b59564fa88ee276cf5"

--- a/docker/docker-compose.tupelobuild.yml
+++ b/docker/docker-compose.tupelobuild.yml
@@ -1,0 +1,14 @@
+version: "3"
+
+services:
+  bootstrap:
+    build: "${TUPELO_BUILD_PATH}"
+      
+  node0:
+    build: "${TUPELO_BUILD_PATH}"
+
+  node1:
+    build: "${TUPELO_BUILD_PATH}"
+  
+  node2:
+    build: "${TUPELO_BUILD_PATH}"

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -3,6 +3,7 @@ version: "3"
 services:
   bootstrap:
     image: quorumcontrol/tupelo:${TUPELO_VERSION}
+    entrypoint: ["/usr/bin/tupelo"]
     command: ["bootstrap-node", "--config", "/tupelo-local/config/bootstrap.toml", 
       "-L", "${TUPELO_LOG_LEVEL:-error}"]
     volumes:
@@ -17,6 +18,7 @@ services:
     image: quorumcontrol/tupelo:${TUPELO_VERSION}
     volumes:
       - tupelo-local:/tupelo-local
+    entrypoint: ["/usr/bin/tupelo"]
     command: ["test-node", "--config", "/tupelo-local/config/node0.toml",
       "-L", "${TUPELO_LOG_LEVEL:-error}"]
 
@@ -24,6 +26,7 @@ services:
     image: quorumcontrol/tupelo:${TUPELO_VERSION}
     volumes:
       - tupelo-local:/tupelo-local
+    entrypoint: ["/usr/bin/tupelo"]
     command: ["test-node", "--config", "/tupelo-local/config/node1.toml",
       "-L", "${TUPELO_LOG_LEVEL:-error}"]
   
@@ -31,6 +34,7 @@ services:
     image: quorumcontrol/tupelo:${TUPELO_VERSION}
     volumes:
       - tupelo-local:/tupelo-local
+    entrypoint: ["/usr/bin/tupelo"]
     command: ["test-node", "--config", "/tupelo-local/config/node2.toml",
       "-L", "${TUPELO_LOG_LEVEL:-error}"]
 

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -3,7 +3,6 @@ version: "3"
 services:
   bootstrap:
     image: quorumcontrol/tupelo:${TUPELO_VERSION}
-    build: "${TUPELO_BUILD_PATH}"
     command: ["bootstrap-node", "--config", "/tupelo-local/config/bootstrap.toml", 
       "-L", "${TUPELO_LOG_LEVEL:-error}"]
     volumes:
@@ -16,7 +15,6 @@ services:
       
   node0:
     image: quorumcontrol/tupelo:${TUPELO_VERSION}
-    build: "${TUPELO_BUILD_PATH}"
     volumes:
       - tupelo-local:/tupelo-local
     command: ["test-node", "--config", "/tupelo-local/config/node0.toml",
@@ -24,7 +22,6 @@ services:
 
   node1:
     image: quorumcontrol/tupelo:${TUPELO_VERSION}
-    build: "${TUPELO_BUILD_PATH}"
     volumes:
       - tupelo-local:/tupelo-local
     command: ["test-node", "--config", "/tupelo-local/config/node1.toml",
@@ -32,7 +29,6 @@ services:
   
   node2:
     image: quorumcontrol/tupelo:${TUPELO_VERSION}
-    build: "${TUPELO_BUILD_PATH}"
     volumes:
       - tupelo-local:/tupelo-local
     command: ["test-node", "--config", "/tupelo-local/config/node2.toml",


### PR DESCRIPTION
docker-compose 1.24.1 and 1.25.0 behave differently when both `build` and `image` are specified
according to the docs, we should be able to have both in the same docker-compose.yml and
"non buildable" services would fallback to pulling an image (aka when `TUPELO_BUILD_PATH` is empty)
that is the behavior in in 1.24.1, but not in 1.25.0 currently. So for now, using a separate override
docker-compose.tupelobuild.yml with the build commands. This may change in the future and can revert to a single docker-compose.yml with both the build and image attributes