### PR TITLE
use a storage path that the dev user (1000) has access to

### DIFF
--- a/docker/config/node0.toml
+++ b/docker/config/node0.toml
@@ -1,4 +1,5 @@
 NotaryGroupConfig = "./notarygroup.toml"
+StoragePath = "/tupelo/storage"
 
 [PrivateKeySet]
 SignKeyHex = "0x4344e3372f1b790016ed86400611fab64d0bba91136518685a7ce34106f1c759"

--- a/docker/config/node1.toml
+++ b/docker/config/node1.toml
@@ -1,5 +1,5 @@
 NotaryGroupConfig = "./notarygroup.toml"
-
+StoragePath = "/tupelo/storage"
 
 [PrivateKeySet]
 SignKeyHex = "0x39a9b8ab3266811852b8b18d1fd0562ffc907f3ecba297c9b2a89f742d349dc9"

--- a/docker/config/node2.toml
+++ b/docker/config/node2.toml
@@ -1,4 +1,5 @@
 NotaryGroupConfig = "./notarygroup.toml"
+StoragePath = "/tupelo/storage"
 
 [PrivateKeySet]
 SignKeyHex = "0x558a546adacea3d761741bf4a6415ef2eeb85bfa457036b59564fa88ee276cf5"


### PR DESCRIPTION
When debugging the tupelo-go-sdk integration tests I found an invalid storage path ( https://github.com/quorumcontrol/tupelo-go-sdk/pull/156 )... tupelo-local has the same problem.

This just sets the storage path to a directory that the 1000 user has access to.